### PR TITLE
Use a generator rather than a callback mechanism for subscription

### DIFF
--- a/adc/cli.py
+++ b/adc/cli.py
@@ -36,12 +36,15 @@ def get_client() -> ADCClient:
     token = get_token_from_env()
     return ADCClient(token)
 
+def print_to_stdout(content: dict):
+    typer.echo(json.dumps(content, indent=4))
+
 
 def fetch_and_output_response(client_method, *args):
     try:
         client = get_client()
         response = getattr(client, client_method)(*args)
-        typer.echo(json.dumps(response, indent=4))
+        print_to_stdout(response)
     except ADCError as e:
         typer.echo(e.error, err=True)
 
@@ -277,9 +280,8 @@ def subscribe_to_study(study_id):
     Notifications will be either for new Samples and Investigations under the specified Study.
     """
     client = get_client()
-    client.subscribe_to_study(
-        study_id, lambda notification: typer.echo(json.dumps(notification, indent=4))
-    )
+    for notification in client.subscribe_to_study(study_id):
+        print_to_stdout(notification)
 
 
 @app.command()
@@ -289,9 +291,8 @@ def subscribe_to_investigation(investigation_id):
     Notifications will be for Jobs created under the specified Study.
     """
     client = get_client()
-    client.subscribe_to_investigation(
-        investigation_id, lambda notification: typer.echo(json.dumps(notification, indent=4))
-    )
+    for notification in client.subscribe_to_investigation(investigation_id):
+        print_to_stdout(notification)
 
 
 @app.command()
@@ -301,6 +302,5 @@ def subscribe_to_job(job_id):
     Notifications will be for Job updates and new Datafiles added to the specified Job.
     """
     client = get_client()
-    client.subscribe_to_job(
-        job_id, lambda notification: typer.echo(json.dumps(notification, indent=4))
-    )
+    for notification in client.subscribe_to_job(job_id):
+        print_to_stdout(notification)

--- a/adc/client.py
+++ b/adc/client.py
@@ -1,9 +1,10 @@
 from gql import Client
 from datetime import datetime
-from typing import BinaryIO, Callable
+from typing import BinaryIO
 from gql.transport.aiohttp import AIOHTTPTransport
 from gql.transport.websockets import WebsocketsTransport
 from adc import queries, exceptions
+from typing import Iterator
 
 
 class ADCClient:
@@ -258,44 +259,41 @@ class ADCClient:
         variables = {"studyId": study_id, "userId": user_id}
         return self._execute(queries.REMOVE_PERMISSIONS, variables)
 
-    def subscribe_to_study(self, study_id: str, callback: Callable):
+    def subscribe_to_study(self, study_id: str) -> Iterator[dict]:
         """
         Subscribe to a study to get notifications when a new sample is added or an investigation is created.
         Arguments:
             study_id: study id
-            callback: function to be executed for each notification, takes in 1 parameter
         """
         variables = {"studyId": study_id}
         for result in self.ws_client.subscribe(
             queries.STUDY_SUBSCRIPTION.query, variable_values=variables
         ):
-            callback(result)
+            yield result
 
-    def subscribe_to_investigation(self, investigation_id: str, callback: Callable):
+    def subscribe_to_investigation(self, investigation_id: str) -> Iterator[dict]:
         """
         Subscribe to an investigation to get notifications when a new job is created.
         Arguments:
             investigation_id: investigation id
-            callback: function to be executed for each notification, takes in 1 parameter
         """
         variables = {"investigationId": investigation_id}
         for result in self.ws_client.subscribe(
                 queries.INVESTIGATION_SUBSCRIPTION.query, variable_values=variables
         ):
-            callback(result)
+            yield result
 
-    def subscribe_to_job(self, job_id: str, callback: Callable):
+    def subscribe_to_job(self, job_id: str) -> Iterator[dict]:
         """
         Subscribe to a job to get notifications when a new datafile is created.
         Arguments:
             job_id: job id
-            callback: function to be executed for each notification, takes in 1 parameter
         """
         variables = {"jobId": job_id}
         for result in self.ws_client.subscribe(
                 queries.JOB_SUBSCRIPTION.query, variable_values=variables
         ):
-            callback(result)
+            yield result
 
     @staticmethod
     def _check_for_errors(response):


### PR DESCRIPTION
This PR changes the "subscription" method in the client from a callback system to a Python generator function.

Generators are a more commonly-used syntax for operations which yield an unknown amount of data, and gives more flexibility on how we can use the functions.

I've also started documenting the functions and using Python's typing syntax, as I was at it.